### PR TITLE
test: cover src/error.rs, guardian error conversions; docs: add performance commands

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -131,17 +131,18 @@ sudo dnf install pkg-config openssl-devel
 ### Performance Tips
 
 - Use `cargo-llvm-cov` for quick checks
+```bash
+# to check for limited test functions in development using cargo-llvm-cov
+cargo llvm-cov test <TEST Fn NAME> --html --open --output-dir ./coverage/
+```
 - Use `cargo-tarpaulin` for detailed analysis
 - Set `--test-threads=1` for deterministic results
 - Use `--timeout 300s` for long-running tests
 
 ```bash
-# to check for limited test functions in development using cargo-llvm-cov
-cargo llvm-cov test test_from_impl_for_error --html --open --output-dir ./coverage/
-
 # to check for detailed analysis on limited number of files in development 
   using cargo-tarpaulin
-cargo tarpaulin --include-files <PATH TO FILE>  --out Html --output-dir ./coverage/
+cargo tarpaulin --include-files <PATH TO FILE> --out Html --output-dir ./coverage/
 ```
 
 ## Coverage Goals

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -135,6 +135,15 @@ sudo dnf install pkg-config openssl-devel
 - Set `--test-threads=1` for deterministic results
 - Use `--timeout 300s` for long-running tests
 
+```bash
+# to check for limited test functions in development using cargo-llvm-cov
+cargo llvm-cov test test_from_impl_for_error --html --open --output-dir ./coverage/
+
+# to check for detailed analysis on limited number of files in development 
+  using cargo-tarpaulin
+cargo tarpaulin --include-files <PATH TO FILE>  --out Html --output-dir ./coverage/
+```
+
 ## Coverage Goals
 
 | Component | Target Coverage |

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -135,15 +135,16 @@ sudo dnf install pkg-config openssl-devel
 # to check for limited test functions in development using cargo-llvm-cov
 cargo llvm-cov test <TEST Fn NAME> --html --open --output-dir ./coverage/
 ```
-- Use `cargo-tarpaulin` for detailed analysis
-- Set `--test-threads=1` for deterministic results
-- Use `--timeout 300s` for long-running tests
 
+- Use `cargo-tarpaulin` for detailed analysis
 ```bash
 # to check for detailed analysis on limited number of files in development 
-  using cargo-tarpaulin
+# using cargo-tarpaulin
 cargo tarpaulin --include-files <PATH TO FILE> --out Html --output-dir ./coverage/
 ```
+
+- Set `--test-threads=1` for deterministic results
+- Use `--timeout 300s` for long-running tests
 
 ## Coverage Goals
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -117,12 +117,16 @@ mod tests {
 	use std::io::Error;
 	
 	#[test]
-	fn test_from_impl_for_errors() {
-		let _b: GuardianError = GuardianError::from(String::from("test string"));
+	fn test_conversion_into_guardian_error() {
+		let test_string = String::from("test string");
+		let guardian_error: GuardianError = test_string.into();
+		assert!(matches!(guardian_error, GuardianError::Other(_)));
+		
 		let _c: GuardianError = GuardianError::from("test string");
 		let _i: GuardianError = GuardianError::from(Error::other("test string"));
 		let io_err: Error = Error::other("test string");
-		let _d: GuardianError = GuardianError::from(cid::Error::from(io_err));
+		let _ge: GuardianError = cid::Error::from(io_err).into();
+		// let _d: GuardianError = GuardianError::from(cid::Error::from(io_err));
 		let _s: GuardianError = GuardianError::from(serde_json::Error::io(Error::other("test string")));
 		let _a: GuardianError = GuardianError::from(serde_cbor::Error::from(Error::other("test string")));
 		let _x: GuardianError = GuardianError::from(Box::<dyn std::error::Error + Send + Sync>::from("test string"));

--- a/src/error.rs
+++ b/src/error.rs
@@ -118,25 +118,34 @@ mod tests {
 	
 	#[test]
 	fn test_conversion_into_guardian_error() {
-		let test_string = String::from("test string");
+		let test_string 				  = String::from("test string");
 		let guardian_error: GuardianError = test_string.into();
 		assert!(matches!(guardian_error, GuardianError::Other(_)));
 		
-		let test_string = "test string";
+		let test_string 				  = "test string";
 		let guardian_error: GuardianError = test_string.into();
 		assert!(matches!(guardian_error, GuardianError::Other(_)));
-		// let _c: GuardianError = GuardianError::from("test string");
 
-		let io_error: Error = Error::other(test_string);
+		let io_error: Error 			  = Error::other(test_string);
 		let guardian_error: GuardianError = io_error.into();
 		assert!(matches!(guardian_error, GuardianError::Io(_)));
-		// let _i: GuardianError = GuardianError::from(Error::other("test string"));
 
-		let io_err: Error = Error::other("test string");
-		let _ge: GuardianError = cid::Error::from(io_err).into();
-		// let _d: GuardianError = GuardianError::from(cid::Error::from(io_err));
-		let _s: GuardianError = GuardianError::from(serde_json::Error::io(Error::other("test string")));
-		let _a: GuardianError = GuardianError::from(serde_cbor::Error::from(Error::other("test string")));
-		let _x: GuardianError = GuardianError::from(Box::<dyn std::error::Error + Send + Sync>::from("test string"));
+		let io_error: Error 			  = Error::other(test_string);
+		let guardian_error: GuardianError = cid::Error::from(io_error).into();
+		assert!(matches!(guardian_error, GuardianError::Cid(_)));
+
+		let io_error: Error 			  = Error::other(test_string);
+		let serde_json_error 			  = serde_json::Error::io(io_error);
+		let guardian_error: GuardianError = serde_json_error.into();
+		assert!(matches!(guardian_error, GuardianError::Json(_)));
+
+		let io_error: Error 			  = Error::other(test_string);
+		let serde_cbor_error 			  = serde_cbor::Error::from(io_error);
+		let guardian_error: GuardianError = serde_cbor_error.into();
+		assert!(matches!(guardian_error, GuardianError::Cbor(_)));
+
+		let boxed_error = Box::<dyn std::error::Error + Send + Sync>::from(test_string);
+		let guardian_error: GuardianError = GuardianError::from(boxed_error);
+		assert!(matches!(guardian_error, GuardianError::Other(_)));
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,8 +122,16 @@ mod tests {
 		let guardian_error: GuardianError = test_string.into();
 		assert!(matches!(guardian_error, GuardianError::Other(_)));
 		
-		let _c: GuardianError = GuardianError::from("test string");
-		let _i: GuardianError = GuardianError::from(Error::other("test string"));
+		let test_string = "test string";
+		let guardian_error: GuardianError = test_string.into();
+		assert!(matches!(guardian_error, GuardianError::Other(_)));
+		// let _c: GuardianError = GuardianError::from("test string");
+
+		let io_error: Error = Error::other(test_string);
+		let guardian_error: GuardianError = io_error.into();
+		assert!(matches!(guardian_error, GuardianError::Io(_)));
+		// let _i: GuardianError = GuardianError::from(Error::other("test string"));
+
 		let io_err: Error = Error::other("test string");
 		let _ge: GuardianError = cid::Error::from(io_err).into();
 		// let _d: GuardianError = GuardianError::from(cid::Error::from(io_err));

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,3 +110,21 @@ impl From<&str> for GuardianError {
 
 /// Alias para Result com GuardianError
 pub type Result<T> = std::result::Result<T, GuardianError>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::io::Error;
+	
+	#[test]
+	fn test_from_impl_for_errors() {
+		let _b: GuardianError = GuardianError::from(String::from("test string"));
+		let _c: GuardianError = GuardianError::from("test string");
+		let _i: GuardianError = GuardianError::from(Error::other("test string"));
+		let io_err: Error = Error::other("test string");
+		let _d: GuardianError = GuardianError::from(cid::Error::from(io_err));
+		let _s: GuardianError = GuardianError::from(serde_json::Error::io(Error::other("test string")));
+		let _a: GuardianError = GuardianError::from(serde_cbor::Error::from(Error::other("test string")));
+		let _x: GuardianError = GuardianError::from(Box::<dyn std::error::Error + Send + Sync>::from("test string"));
+	}
+}


### PR DESCRIPTION
Related to #4

Hi @wmaslonek, I have added test function only for the src/error.rs file (least number of lines to cover). I would like to make sure the coding pattern and flow of test function are consistent with the project guidelines.
Along with the test function, I have added a couple of commands in the docs/COVERAGE.md file under the 'performance tips' section.

