### PR TITLE
DOCS UPDATE - (pg): document connection-string usage everywhere + runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,10 @@ no GuardianDB-specific client code.
 
 ```bash
 cargo run --features pgwire --bin guardian-pgwire        # PostgreSQL gateway on 127.0.0.1:15432
-psql 'postgres://guardian:guardian@127.0.0.1:15432/app'
+
+# Any PostgreSQL client connects with an ordinary connection string.
+# (sslmode=disable: the loopback gateway does not negotiate TLS.)
+psql 'postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable'
 ```
 
 ```ts
@@ -274,6 +277,8 @@ import { DataSource } from "typeorm";
 const ds = new DataSource({
   type: "postgres", host: "127.0.0.1", port: 15432,
   username: "guardian", password: "guardian", database: "app",
+  // or the single-string form:
+  // type: "postgres", url: "postgres://guardian:guardian@127.0.0.1:15432/app", ssl: false,
   synchronize: true, entities: [User, Post, Org],
 });
 await ds.initialize();   // schema sync, migrations, repositories, QueryBuilder, transactions

--- a/docs/postgres-compat.md
+++ b/docs/postgres-compat.md
@@ -91,16 +91,46 @@ gateway **exactly** as to the in-memory one — same wire protocol, same SQL, no
 GuardianDB-specific code. The full runnable source is
 [`examples/postgres_iroh_gateway.rs`](../examples/postgres_iroh_gateway.rs).
 
-## 2. Connecting with `psql`
+## 2. Connection strings
+
+Every standard client connects with an ordinary PostgreSQL connection string
+(URI). With the default gateway flags the canonical string is:
+
+```
+postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable
+```
+
+- **user/password** — `guardian`/`guardian` by default (`--username` to change;
+  the gateway accepts the password without enforcing it).
+- **database** — `app` by default (`--database`).
+- **`sslmode=disable`** — the gateway is a plaintext loopback TCP socket and
+  does not negotiate TLS. libpq-based clients (`psql`, DBeaver, Python's
+  `psycopg`) may try SSL first, so pass `sslmode=disable` explicitly;
+  node-postgres and TypeORM default to no-SSL and work without it.
+
+### `psql`
 
 ```bash
-psql 'postgres://guardian:guardian@127.0.0.1:15432/app'
+psql 'postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable'
 ```
 
 ```sql
 CREATE TABLE users (id SERIAL PRIMARY KEY, email TEXT UNIQUE NOT NULL, data JSONB);
 INSERT INTO users (email, data) VALUES ('a@x.com', '{"plan":"pro"}') RETURNING id;
 SELECT count(*) FROM users;
+```
+
+### node-postgres (`pg`)
+
+```ts
+import pg from "pg";
+
+const client = new pg.Client({
+  connectionString: "postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable",
+});
+await client.connect();
+const { rows } = await client.query("SELECT count(*) FROM users");
+await client.end();
 ```
 
 ## 3. Connecting with TypeORM (`type: "postgres"`)
@@ -121,6 +151,18 @@ const ds = new DataSource({
   entities: [User, Post, Org],
 });
 await ds.initialize();
+```
+
+Or equivalently with a single connection string via `url`:
+
+```ts
+const ds = new DataSource({
+  type: "postgres",
+  url: process.env.DATABASE_URL ?? "postgres://guardian:guardian@127.0.0.1:15432/app",
+  ssl: false,
+  synchronize: true,
+  entities: [User, Post, Org],
+});
 ```
 
 `synchronize`, schema **re-introspection**, migrations (`QueryRunner`),

--- a/examples/postgres-typeorm/README.md
+++ b/examples/postgres-typeorm/README.md
@@ -106,11 +106,30 @@ The same typed-model + Zod pattern is also shown against the embedded
 
 ## Connecting to a long-running gateway
 
-In a real deployment, start the gateway separately and point TypeORM at it:
+In a real deployment, start the gateway separately and point any PostgreSQL
+client at it with an ordinary connection string:
 
 ```bash
 cargo run --features pgwire --bin guardian-pgwire            # listens on 127.0.0.1:15432
+
+# canonical connection string (sslmode=disable: the gateway has no TLS;
+# needed by libpq clients like psql — node-postgres/TypeORM work without it)
+psql 'postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable'
 ```
+
+With TypeORM, either the single-string form:
+
+```ts
+const ds = new DataSource({
+  type: "postgres",
+  url: "postgres://guardian:guardian@127.0.0.1:15432/app",
+  ssl: false,
+  synchronize: true,
+  entities: [User, Post, Org],
+});
+```
+
+or discrete options:
 
 ```ts
 const ds = new DataSource({
@@ -125,10 +144,20 @@ const ds = new DataSource({
 });
 ```
 
-The TypeORM migration CLI works too:
+This example's [`data-source.ts`](./src/data-source.ts) honors `DATABASE_URL`,
+so the migration CLI and demos accept a connection string directly:
 
 ```bash
+DATABASE_URL=postgres://guardian:guardian@127.0.0.1:15432/app npm run migration:run
+# or with discrete PG* variables:
 PGPORT=15432 npm run migration:run
+```
+
+For a runnable end-to-end demo of both connection-string forms, see
+[`src/connection-string.ts`](./src/connection-string.ts):
+
+```bash
+npm run connection-string
 ```
 
 ## Native GuardianDB driver (optional)

--- a/examples/postgres-typeorm/package.json
+++ b/examples/postgres-typeorm/package.json
@@ -8,7 +8,8 @@
     "demo": "node --import tsx src/demo.ts",
     "crud": "node --import tsx src/crud.ts",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/data-source.ts",
-    "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/data-source.ts"
+    "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/data-source.ts",
+    "connection-string": "node --import tsx src/connection-string.ts"
   },
   "dependencies": {
     "pg": "^8.11.0",

--- a/examples/postgres-typeorm/src/connection-string.ts
+++ b/examples/postgres-typeorm/src/connection-string.ts
@@ -1,0 +1,64 @@
+// Connecting to the GuardianDB PostgreSQL gateway with an ordinary
+// connection string — the same `postgres://` URI you would use against a
+// real PostgreSQL server. Run with `npm run connection-string`.
+//
+// Canonical form (default gateway flags):
+//
+//   postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable
+//
+// `sslmode=disable` matters for libpq-based clients (psql, DBeaver, psycopg):
+// the gateway is a plaintext loopback socket and does not negotiate TLS.
+// node-postgres and TypeORM default to no-SSL and work without it.
+//
+// This demo spawns its own gateway on an ephemeral port to stay
+// self-contained; against a long-running gateway you would just hardcode
+// port 15432 or read the string from DATABASE_URL.
+
+import "reflect-metadata";
+import pg from "pg";
+import { DataSource } from "typeorm";
+import { Org } from "./entities/Org";
+import { User } from "./entities/User";
+import { Post } from "./entities/Post";
+import { startGateway } from "./gateway";
+
+async function main() {
+  const gw = await startGateway();
+  const url = `postgres://guardian:guardian@127.0.0.1:${gw.port}/app`;
+  console.log(`gateway ready — connection string: ${url}`);
+
+  try {
+    // 1. node-postgres: pass the string as `connectionString`.
+    const client = new pg.Client({ connectionString: `${url}?sslmode=disable` });
+    await client.connect();
+    await client.query("CREATE TABLE greetings (id INT PRIMARY KEY, msg TEXT NOT NULL)");
+    await client.query("INSERT INTO greetings VALUES ($1, $2)", [1, "hello over a connection string"]);
+    const { rows } = await client.query("SELECT msg FROM greetings WHERE id = $1", [1]);
+    console.log("node-postgres:", rows[0].msg);
+    await client.end();
+
+    // 2. TypeORM: pass the string as `url` (instead of host/port/username/...).
+    const ds = new DataSource({
+      type: "postgres",
+      url,
+      ssl: false,
+      entities: [Org, User, Post],
+      synchronize: true,
+      logging: ["error", "warn"],
+    });
+    await ds.initialize();
+    const orgs = ds.getRepository(Org);
+    const org = await orgs.save(orgs.create({ name: "Acme" }));
+    console.log("typeorm:", `saved org #${org.id} via url-configured DataSource`);
+    await ds.destroy();
+
+    console.log("\nConnection-string demo complete ✅");
+  } finally {
+    gw.stop();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/postgres-typeorm/src/data-source.ts
+++ b/examples/postgres-typeorm/src/data-source.ts
@@ -11,8 +11,24 @@ import { Init1700000000000 } from "./migrations/1700000000000-Init";
  * This is exactly what you would write against a real PostgreSQL server — the
  * gateway speaks the PostgreSQL wire protocol, so `type: "postgres"` is all that
  * is required.
+ *
+ * Set DATABASE_URL to use a single connection string instead of the discrete
+ * PG* variables, e.g.:
+ *   DATABASE_URL=postgres://guardian:guardian@127.0.0.1:15432/app
  */
 export function options(overrides: Partial<DataSourceOptions> = {}): DataSourceOptions {
+  if (process.env.DATABASE_URL) {
+    return {
+      type: "postgres",
+      url: process.env.DATABASE_URL,
+      ssl: false, // the gateway is a plaintext loopback socket (no TLS)
+      entities: [Org, User, Post],
+      migrations: [Init1700000000000],
+      synchronize: false,
+      logging: ["error", "warn"],
+      ...overrides,
+    } as DataSourceOptions;
+  }
   return {
     type: "postgres",
     host: process.env.PGHOST ?? "127.0.0.1",

--- a/packages/guardiandb-postgres-typeorm/README.md
+++ b/packages/guardiandb-postgres-typeorm/README.md
@@ -74,6 +74,28 @@ Set `GUARDIAN_PGWIRE_BIN` to point at the gateway binary, or pass `{ binary }`.
 > gateway (the `sql` feature of the `guardian-db` crate). The default
 > `guardian-pgwire` binary is in-memory and accepts these flags as no-ops.
 
+## Connecting with a plain connection string
+
+`GuardianDataSource` manages the gateway for you, but you don't need this
+package at all to talk to an already-running gateway — any PostgreSQL client
+connects with an ordinary connection string:
+
+```
+postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable
+```
+
+```ts
+// node-postgres
+const client = new pg.Client({ connectionString: "postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable" });
+
+// plain TypeORM
+const ds = new DataSource({ type: "postgres", url: "postgres://guardian:guardian@127.0.0.1:15432/app", ssl: false, entities: [...] });
+```
+
+Pass `sslmode=disable` for libpq-based clients (`psql`, DBeaver, psycopg) —
+the gateway is a plaintext loopback socket and does not negotiate TLS.
+node-postgres and TypeORM default to no-SSL and work without it.
+
 ## Build / test
 
 ```bash


### PR DESCRIPTION
Make the canonical connection string explicit across all Postgres-layer surfaces:

  postgres://guardian:guardian@127.0.0.1:15432/app?sslmode=disable

- docs/postgres-compat.md: new "Connection strings" section (defaults, why sslmode=disable for libpq clients — the gateway is a plaintext loopback socket with no TLS), node-postgres connectionString snippet, and the TypeORM `url` form incl. DATABASE_URL.
- Root README: connection-string note next to the psql line and the single-string TypeORM alternative.
- guardiandb-postgres-typeorm README: "Connecting with a plain connection string" section — the embedded DataSource is optional; any PG client can use a URI against a long-running gateway.
- examples/postgres-typeorm: data-source.ts now honors DATABASE_URL (single string) as an alternative to the discrete PG* variables; README leads the long-running-gateway section with the URI; new runnable src/connection-string.ts (`npm run connection-string`) demonstrating both pg.Client connectionString and TypeORM url against a spawned gateway.

Verified: tsc clean; demo run green (node-postgres round-trip + TypeORM save via url); DATABASE_URL branch smoke-tested.
