### PR TITLE
Implement Supabase Edge Functions compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,11 @@ path = "tests/supabase_graphql.rs"
 required-features = ["supabase"]
 
 [[test]]
+name = "supabase_functions"
+path = "tests/supabase_functions.rs"
+required-features = ["supabase"]
+
+[[test]]
 name = "compute_delegation"
 path = "tests/compute_delegation.rs"
 required-features = ["compute"]

--- a/src/supabase/functions.rs
+++ b/src/supabase/functions.rs
@@ -1,0 +1,1462 @@
+//! Supabase Edge Functions-compatible service on top of Guardian Compute.
+//!
+//! Speaks the two halves of Supabase's Functions surface:
+//!
+//! * `/functions/v1/{slug}` — the **invocation** endpoint every Supabase client
+//!   library posts to. Verifies the caller (default `verify_jwt=true`, matching
+//!   the CLI), fetches the deployed WebAssembly body for `slug`, and runs it
+//!   inside the Guardian Compute WASM sandbox with the caller's request
+//!   folded into an opaque input envelope. The guest returns an output
+//!   envelope (status + headers + body) which is rendered as the HTTP
+//!   response. Supports `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and the CORS
+//!   `OPTIONS` preflight (204).
+//!
+//! * `/functions/v1/_admin/*` — the **management** endpoints Supabase's CLI
+//!   (`supabase functions deploy|list|delete`) and Studio talk to. All admin
+//!   routes require `service_role`; every mutation goes through parameterised
+//!   SQL against the `functions` schema (bootstrapped on first use).
+//!
+//! ## Runtime substrate
+//!
+//! Function bodies are WebAssembly modules using the Guardian Compute ABI
+//! (`gdb_alloc` + a `handler` export with signature `(ptr, len) -> i64` where
+//! the return packs `(out_ptr << 32) | out_len`). Input is a CBOR-encoded
+//! [`InvocationInput`]; output is a CBOR-encoded [`InvocationOutput`]. Every
+//! run gets a fresh `Store` and a hard resource ceiling — the same isolation
+//! [`crate::compute::WasmRuntime`] enforces for delegated tasks. The only
+//! host capability linked in by default is `gdb.log`, so a function can
+//! `console.log`-equivalently emit into GuardianDB's tracing without any
+//! filesystem, network, or environment access.
+//!
+//! When a project sets `verify_jwt=false` (the CLI's `--no-verify-jwt`), the
+//! bearer/apikey is still required for admission but a missing `Authorization`
+//! is allowed. When it is `true` (the default), the caller MUST supply an
+//! `apikey` header AND a matching `Authorization: Bearer` token, and both
+//! must verify against the project keys — a mismatch renders the same
+//! `SUPA_COMPAT_INVALID_JWT` shape as `/rest/v1`.
+//!
+//! ## Storage model
+//!
+//! The `functions` schema (see [`BOOTSTRAP_SQL`]) holds three tables:
+//!
+//! * `functions.functions` — one row per deployed function (slug, name,
+//!   verify_jwt, version, timestamps).
+//! * `functions._code` — the WASM body, keyed by function id (`bytea`).
+//! * `functions.secrets` — per-function environment variables (name/value),
+//!   exposed to the guest through the input envelope's `env` map.
+//!
+//! All three tables have RLS enabled with **no default policies** — only
+//! `service_role` reaches them, exactly like `storage.buckets`.
+//!
+//! ## Error shape
+//!
+//! Errors match Supabase's Functions runtime shape:
+//! `{"error": <code>, "msg": <message>}`. The full taxonomy lives in
+//! [`functions_error`] / [`FunctionsErrorCode`]. Gateway-level errors from
+//! outside this module (missing apikey, invalid JWT) still render in the
+//! shared `{code, message}` shape — that is the caller's contract with the
+//! auth layer, unchanged here.
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::{DefaultBodyLimit, Path, RawQuery, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{any, delete, get};
+use axum::{Extension, Json as AxumJson};
+use base64::Engine as _;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as Json, json};
+use uuid::Uuid;
+
+use crate::sql::{ExecResult, RelationalStorage, SqlValue};
+use crate::supabase::error::{SupaError, status_for_sqlstate};
+use crate::supabase::gateway::{AppState, AuthContext, run_batch, run_sql_as};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum accepted request body for a function invocation (bytes).
+/// Deliberately conservative — function inputs travel through the SQL layer's
+/// JSON envelope, and huge payloads should go through Storage instead.
+pub const MAX_INVOKE_BODY_BYTES: usize = 6 * 1024 * 1024;
+
+/// Maximum accepted WebAssembly bundle size when deploying (bytes).
+pub const MAX_WASM_BUNDLE_BYTES: usize = 50 * 1024 * 1024;
+
+/// The exported guest function every deployed WASM module must implement.
+pub const HANDLER_EXPORT: &str = "handler";
+
+/// Wall-clock ceiling for a single invocation, in milliseconds. Matches
+/// Supabase's default Edge Functions timeout.
+pub const DEFAULT_TIMEOUT_MS: u64 = 60_000;
+
+/// Ceiling on the wasm module's linear memory for a single invocation.
+pub const DEFAULT_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Ceiling on wasm fuel for a single invocation.
+pub const DEFAULT_FUEL: u64 = 5_000_000_000;
+
+// ---------------------------------------------------------------------------
+// Schema bootstrap
+// ---------------------------------------------------------------------------
+
+/// The `functions` schema bootstrap. RLS is enabled with no default policies
+/// so only `service_role` bypasses.
+pub const BOOTSTRAP_SQL: &str = "
+CREATE SCHEMA IF NOT EXISTS functions;
+
+CREATE TABLE IF NOT EXISTS functions.functions (
+    id uuid PRIMARY KEY,
+    slug text NOT NULL UNIQUE,
+    name text NOT NULL,
+    verify_jwt boolean NOT NULL,
+    version bigint NOT NULL,
+    status text NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS functions._code (
+    function_id uuid PRIMARY KEY,
+    body bytea NOT NULL,
+    content_sha256 text NOT NULL,
+    size_bytes bigint NOT NULL,
+    updated_at timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS functions.secrets (
+    function_id uuid NOT NULL,
+    name text NOT NULL,
+    value text NOT NULL,
+    updated_at timestamptz NOT NULL,
+    PRIMARY KEY (function_id, name)
+);
+
+ALTER TABLE functions.functions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE functions._code ENABLE ROW LEVEL SECURITY;
+ALTER TABLE functions.secrets ENABLE ROW LEVEL SECURITY;
+";
+
+/// The columns projected for every function metadata read.
+const FUNCTION_COLUMNS: &str =
+    "id, slug, name, verify_jwt, version, status, created_at, updated_at";
+
+/// Bootstrap the `functions` schema exactly once per gateway instance.
+pub async fn ensure_schema<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+) -> Result<(), SupaError> {
+    state
+        .functions_ready
+        .get_or_try_init(|| async {
+            run_batch(&state.db, "service_role", BOOTSTRAP_SQL)
+                .await
+                .map_err(SupaError::Sql)?;
+            Ok::<(), SupaError>(())
+        })
+        .await
+        .map(|_| ())
+}
+
+// ---------------------------------------------------------------------------
+// Error rendering
+// ---------------------------------------------------------------------------
+
+/// The stable error codes the functions surface can surface. The wire body
+/// is always `{"error": <code>, "msg": <message>}` at the associated HTTP
+/// status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionsErrorCode {
+    /// The function slug is not deployed.
+    NotFound,
+    /// The function's WASM body failed to compile or instantiate.
+    BootError,
+    /// The function trapped, exceeded fuel, memory, or deadline, or violated
+    /// the ABI at runtime.
+    RuntimeError,
+    /// The invocation input was too large or malformed.
+    BadRequest,
+    /// The service role is required (admin routes).
+    Forbidden,
+    /// The deployed body was not a valid WebAssembly module.
+    InvalidWasm,
+    /// An internal gateway failure (never contains a secret).
+    Internal,
+}
+
+impl FunctionsErrorCode {
+    fn status(self) -> StatusCode {
+        match self {
+            FunctionsErrorCode::NotFound => StatusCode::NOT_FOUND,
+            FunctionsErrorCode::BootError => StatusCode::INTERNAL_SERVER_ERROR,
+            FunctionsErrorCode::RuntimeError => StatusCode::INTERNAL_SERVER_ERROR,
+            FunctionsErrorCode::BadRequest => StatusCode::BAD_REQUEST,
+            FunctionsErrorCode::Forbidden => StatusCode::FORBIDDEN,
+            FunctionsErrorCode::InvalidWasm => StatusCode::BAD_REQUEST,
+            FunctionsErrorCode::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            FunctionsErrorCode::NotFound => "SUPA_COMPAT_FUNCTION_NOT_FOUND",
+            FunctionsErrorCode::BootError => "SUPA_COMPAT_FUNCTION_BOOT_ERROR",
+            FunctionsErrorCode::RuntimeError => "SUPA_COMPAT_FUNCTION_RUNTIME_ERROR",
+            FunctionsErrorCode::BadRequest => "SUPA_COMPAT_FUNCTION_BAD_REQUEST",
+            FunctionsErrorCode::Forbidden => "SUPA_COMPAT_FUNCTION_FORBIDDEN",
+            FunctionsErrorCode::InvalidWasm => "SUPA_COMPAT_FUNCTION_INVALID_WASM",
+            FunctionsErrorCode::Internal => "SUPA_COMPAT_FUNCTION_INTERNAL",
+        }
+    }
+}
+
+/// Render a functions-shaped error: `{"error": <code>, "msg": <message>}`.
+pub fn functions_error(code: FunctionsErrorCode, msg: impl Into<String>) -> Response {
+    let msg = msg.into();
+    (
+        code.status(),
+        AxumJson(json!({
+            "error": code.code(),
+            "msg": msg,
+        })),
+    )
+        .into_response()
+}
+
+/// Convert an infrastructure error to the functions error shape.
+fn functions_error_from(e: SupaError) -> Response {
+    if let SupaError::Sql(err) = &e {
+        let state = err.sqlstate();
+        return functions_error(
+            match status_for_sqlstate(state) {
+                StatusCode::NOT_FOUND => FunctionsErrorCode::NotFound,
+                StatusCode::FORBIDDEN => FunctionsErrorCode::Forbidden,
+                StatusCode::BAD_REQUEST => FunctionsErrorCode::BadRequest,
+                _ => FunctionsErrorCode::Internal,
+            },
+            err.to_string(),
+        );
+    }
+    match e {
+        SupaError::Forbidden(what) => functions_error(
+            FunctionsErrorCode::Forbidden,
+            format!("{what} requires the service_role key"),
+        ),
+        SupaError::BadRequest(m) => functions_error(FunctionsErrorCode::BadRequest, m),
+        SupaError::Internal(m) => {
+            if let Some(rest) = m.strip_prefix("__functions_boot::") {
+                functions_error(FunctionsErrorCode::BootError, rest)
+            } else if let Some(rest) = m.strip_prefix("__functions_runtime::") {
+                functions_error(FunctionsErrorCode::RuntimeError, rest)
+            } else {
+                functions_error(FunctionsErrorCode::Internal, m)
+            }
+        }
+        other => other.into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// The invocation router mounted at `/functions/v1` **behind** the apikey
+/// middleware. Both admin (`/_admin/...`) and invocation (`/{slug}`) routes
+/// live here so a single apikey layer covers the whole namespace.
+pub fn router<S: RelationalStorage + 'static>() -> Router<AppState<S>> {
+    Router::new()
+        // Admin: service_role-only CRUD.
+        .route(
+            "/_admin/functions",
+            get(list_functions::<S>).post(create_function::<S>),
+        )
+        .route(
+            "/_admin/functions/{slug}",
+            get(get_function::<S>)
+                .patch(update_function::<S>)
+                .delete(delete_function::<S>),
+        )
+        .route(
+            "/_admin/functions/{slug}/body",
+            get(get_function_body::<S>).put(put_function_body::<S>),
+        )
+        .route(
+            "/_admin/functions/{slug}/secrets",
+            get(list_secrets::<S>)
+                .post(upsert_secret::<S>)
+                .delete(delete_all_secrets::<S>),
+        )
+        .route(
+            "/_admin/functions/{slug}/secrets/{name}",
+            delete(delete_secret::<S>),
+        )
+        // Invocation: OPTIONS is unauthenticated CORS preflight, all others
+        // are authenticated per verify_jwt.
+        .route("/{slug}", any(invoke_function::<S>))
+        .layer(DefaultBodyLimit::max(MAX_INVOKE_BODY_BYTES))
+}
+
+// ---------------------------------------------------------------------------
+// Admin: CRUD on functions.functions
+// ---------------------------------------------------------------------------
+
+/// The JSON shape for creating a function.
+#[derive(Debug, Clone, Deserialize)]
+struct CreateFunctionBody {
+    slug: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default = "default_verify_jwt")]
+    verify_jwt: bool,
+    /// Base64-encoded `.wasm` bytes. Optional at create time so a slug can
+    /// be reserved and the body PUT separately (matches Supabase's CLI flow).
+    #[serde(default)]
+    body: Option<String>,
+}
+
+fn default_verify_jwt() -> bool {
+    true
+}
+
+/// The JSON shape for updating a function.
+#[derive(Debug, Clone, Deserialize)]
+struct UpdateFunctionBody {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    verify_jwt: Option<bool>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+async fn list_functions<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let result = run_sql_as(
+            &state.db,
+            &auth,
+            &format!("SELECT {FUNCTION_COLUMNS} FROM functions.functions ORDER BY slug"),
+            vec![],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(AxumJson(Json::Array(result_objects(result)?)).into_response())
+    })
+    .await
+}
+
+async fn create_function<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    body: Bytes,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let req: CreateFunctionBody = serde_json::from_slice(&body)
+            .map_err(|e| SupaError::BadRequest(format!("invalid create body: {e}")))?;
+        validate_slug(&req.slug)?;
+
+        let wasm = match req.body.as_deref() {
+            Some(b64) => Some(decode_wasm(b64)?),
+            None => None,
+        };
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let name = req.name.unwrap_or_else(|| req.slug.clone());
+        let status = if wasm.is_some() { "ACTIVE" } else { "PENDING" };
+
+        let insert = run_sql_as(
+            &state.db,
+            &auth,
+            "INSERT INTO functions.functions \
+             (id, slug, name, verify_jwt, version, status, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, 1, $5, $6, $6)",
+            vec![
+                SqlValue::Uuid(id),
+                SqlValue::Text(req.slug.clone()),
+                SqlValue::Text(name),
+                SqlValue::Bool(req.verify_jwt),
+                SqlValue::Text(status.to_string()),
+                SqlValue::Timestamptz(now),
+            ],
+        )
+        .await;
+        if let Err(e) = insert {
+            if e.sqlstate() == "23505" {
+                return Ok(functions_error(
+                    FunctionsErrorCode::BadRequest,
+                    format!("function slug \"{}\" already exists", req.slug),
+                ));
+            }
+            return Err(SupaError::Sql(e));
+        }
+
+        if let Some(wasm) = wasm {
+            insert_code(&state, &auth, id, &wasm, now).await?;
+        }
+
+        let row = fetch_one_function(&state, &auth, &req.slug).await?;
+        Ok((StatusCode::CREATED, AxumJson(row)).into_response())
+    })
+    .await
+}
+
+async fn get_function<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        match load_function_row(&state, &auth, &slug).await? {
+            Some(row) => Ok(AxumJson(row).into_response()),
+            None => Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            )),
+        }
+    })
+    .await
+}
+
+async fn update_function<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+    body: Bytes,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let req: UpdateFunctionBody = serde_json::from_slice(&body)
+            .map_err(|e| SupaError::BadRequest(format!("invalid update body: {e}")))?;
+
+        let Some(existing) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&existing)?;
+        let now = Utc::now();
+        let mut sets = vec!["updated_at = $1".to_string()];
+        let mut params: Vec<SqlValue> = vec![SqlValue::Timestamptz(now)];
+        if let Some(name) = req.name {
+            params.push(SqlValue::Text(name));
+            sets.push(format!("name = ${}", params.len()));
+        }
+        if let Some(verify) = req.verify_jwt {
+            params.push(SqlValue::Bool(verify));
+            sets.push(format!("verify_jwt = ${}", params.len()));
+        }
+        let bumps_version = req.body.is_some();
+        if bumps_version {
+            sets.push("version = version + 1".to_string());
+            sets.push("status = 'ACTIVE'".to_string());
+        }
+        params.push(SqlValue::Text(slug.clone()));
+        let sql = format!(
+            "UPDATE functions.functions SET {} WHERE slug = ${}",
+            sets.join(", "),
+            params.len()
+        );
+        run_sql_as(&state.db, &auth, &sql, params)
+            .await
+            .map_err(SupaError::Sql)?;
+
+        if let Some(b64) = req.body {
+            let wasm = decode_wasm(&b64)?;
+            replace_code(&state, &auth, id, &wasm, now).await?;
+        }
+
+        let row = fetch_one_function(&state, &auth, &slug).await?;
+        Ok(AxumJson(row).into_response())
+    })
+    .await
+}
+
+async fn delete_function<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        // Cascade by hand — the engine's foreign keys are optional and the
+        // storage.rs pattern (delete code + secrets + metadata) is what we
+        // mirror here.
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions._code WHERE function_id = $1",
+            vec![SqlValue::Uuid(id)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions.secrets WHERE function_id = $1",
+            vec![SqlValue::Uuid(id)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions.functions WHERE slug = $1",
+            vec![SqlValue::Text(slug)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(StatusCode::NO_CONTENT.into_response())
+    })
+    .await
+}
+
+async fn get_function_body<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        let Some(bytes) = load_code(&state, &auth, id).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" has no deployed body"),
+            ));
+        };
+        Ok((
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/wasm")],
+            bytes,
+        )
+            .into_response())
+    })
+    .await
+}
+
+async fn put_function_body<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        // Accept either raw application/wasm bytes or base64 in a text body.
+        let content_type = headers
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let wasm = if content_type.starts_with("application/wasm")
+            || content_type.starts_with("application/octet-stream")
+        {
+            body.to_vec()
+        } else {
+            let text = std::str::from_utf8(&body).map_err(|_| {
+                SupaError::BadRequest("body must be application/wasm or base64 text".into())
+            })?;
+            decode_wasm(text.trim())?
+        };
+        if wasm.len() > MAX_WASM_BUNDLE_BYTES {
+            return Ok(functions_error(
+                FunctionsErrorCode::BadRequest,
+                format!(
+                    "wasm body exceeds {MAX_WASM_BUNDLE_BYTES} bytes ({} bytes)",
+                    wasm.len()
+                ),
+            ));
+        }
+        validate_wasm_magic(&wasm)?;
+        let now = Utc::now();
+        replace_code(&state, &auth, id, &wasm, now).await?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "UPDATE functions.functions \
+             SET version = version + 1, status = 'ACTIVE', updated_at = $1 \
+             WHERE slug = $2",
+            vec![SqlValue::Timestamptz(now), SqlValue::Text(slug.clone())],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        let row = fetch_one_function(&state, &auth, &slug).await?;
+        Ok(AxumJson(row).into_response())
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Admin: secrets
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UpsertSecretBody {
+    name: String,
+    value: String,
+}
+
+async fn list_secrets<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        // Never surface the value; return only names + timestamps.
+        let result = run_sql_as(
+            &state.db,
+            &auth,
+            "SELECT name, updated_at FROM functions.secrets \
+             WHERE function_id = $1 ORDER BY name",
+            vec![SqlValue::Uuid(id)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(AxumJson(Json::Array(result_objects(result)?)).into_response())
+    })
+    .await
+}
+
+async fn upsert_secret<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+    body: Bytes,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let req: UpsertSecretBody = serde_json::from_slice(&body)
+            .map_err(|e| SupaError::BadRequest(format!("invalid secret body: {e}")))?;
+        validate_secret_name(&req.name)?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        let now = Utc::now();
+        // Upsert without ON CONFLICT (portable across engine flavours): DELETE
+        // then INSERT, both parameterised.
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions.secrets WHERE function_id = $1 AND name = $2",
+            vec![SqlValue::Uuid(id), SqlValue::Text(req.name.clone())],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "INSERT INTO functions.secrets (function_id, name, value, updated_at) \
+             VALUES ($1, $2, $3, $4)",
+            vec![
+                SqlValue::Uuid(id),
+                SqlValue::Text(req.name.clone()),
+                SqlValue::Text(req.value),
+                SqlValue::Timestamptz(now),
+            ],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(AxumJson(json!({ "name": req.name, "updated_at": now.to_rfc3339() })).into_response())
+    })
+    .await
+}
+
+async fn delete_secret<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path((slug, name)): Path<(String, String)>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions.secrets WHERE function_id = $1 AND name = $2",
+            vec![SqlValue::Uuid(id), SqlValue::Text(name)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(StatusCode::NO_CONTENT.into_response())
+    })
+    .await
+}
+
+async fn delete_all_secrets<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+) -> Response {
+    run(async {
+        require_service_role(&auth)?;
+        ensure_schema(&state).await?;
+        let Some(row) = load_function_row(&state, &auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let id = extract_id(&row)?;
+        run_sql_as(
+            &state.db,
+            &auth,
+            "DELETE FROM functions.secrets WHERE function_id = $1",
+            vec![SqlValue::Uuid(id)],
+        )
+        .await
+        .map_err(SupaError::Sql)?;
+        Ok(StatusCode::NO_CONTENT.into_response())
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Invocation
+// ---------------------------------------------------------------------------
+
+/// The JSON envelope handed to the guest as CBOR input.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationInput {
+    pub method: String,
+    pub url: String,
+    pub path: String,
+    pub query: String,
+    pub headers: Vec<(String, String)>,
+    /// Base64-encoded request body (may be empty).
+    #[serde(default)]
+    pub body_b64: String,
+    /// Per-function env (name/value pairs from `functions.secrets`).
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+    /// The caller's resolved role (`anon` / `authenticated` / `service_role`).
+    pub role: String,
+    /// The caller's `x-request-id`.
+    pub request_id: String,
+    /// The raw bearer JWT the caller supplied (when verify_jwt=true this is
+    /// verified). May be empty when verify_jwt=false and no bearer was sent.
+    #[serde(default)]
+    pub jwt: String,
+}
+
+/// The JSON envelope the guest returns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationOutput {
+    #[serde(default = "default_status")]
+    pub status: u16,
+    #[serde(default)]
+    pub headers: Vec<(String, String)>,
+    /// Base64-encoded response body.
+    #[serde(default)]
+    pub body_b64: String,
+}
+
+fn default_status() -> u16 {
+    200
+}
+
+async fn invoke_function<S: RelationalStorage + 'static>(
+    State(state): State<AppState<S>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(slug): Path<String>,
+    method: Method,
+    headers: HeaderMap,
+    RawQuery(query): RawQuery,
+    body: Bytes,
+) -> Response {
+    // CORS preflight is answered without touching the DB.
+    if method == Method::OPTIONS {
+        return cors_preflight_response(&headers);
+    }
+    run(async {
+        ensure_schema(&state).await?;
+
+        // Routing metadata lookup runs as service_role: an anon caller cannot
+        // read `functions.functions` under the schema's default-deny RLS, and
+        // whether a slug is deployed is not a user-visible fact — it is a
+        // routing decision equivalent to the storage-api's `_blobs` fetch.
+        let admin_auth = as_service_role(&auth);
+        let Some(row) = load_function_row(&state, &admin_auth, &slug).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" not found"),
+            ));
+        };
+        let verify_jwt = extract_bool(&row, "verify_jwt").unwrap_or(true);
+        if verify_jwt && auth.claims.is_none() {
+            return Ok(functions_error(
+                FunctionsErrorCode::Forbidden,
+                "this function requires a bearer token (verify_jwt=true)",
+            ));
+        }
+        let id = extract_id(&row)?;
+        let Some(wasm) = load_code(&state, &admin_auth, id).await? else {
+            return Ok(functions_error(
+                FunctionsErrorCode::NotFound,
+                format!("function \"{slug}\" has no deployed body"),
+            ));
+        };
+        let secrets = load_secrets(&state, &admin_auth, id).await?;
+
+        let query_str = query.unwrap_or_default();
+        let path = format!("/functions/v1/{slug}");
+        let url = format!(
+            "{}{}{}",
+            state.project.api_url.trim_end_matches('/'),
+            path,
+            if query_str.is_empty() {
+                String::new()
+            } else {
+                format!("?{query_str}")
+            },
+        );
+
+        let mut header_pairs = Vec::with_capacity(headers.len());
+        for (k, v) in headers.iter() {
+            if let Ok(s) = v.to_str() {
+                header_pairs.push((k.as_str().to_string(), s.to_string()));
+            }
+        }
+
+        let jwt = auth
+            .claims
+            .as_ref()
+            .and_then(|_| bearer_from(&headers))
+            .unwrap_or_default();
+
+        let input = InvocationInput {
+            method: method.to_string(),
+            url,
+            path,
+            query: query_str,
+            headers: header_pairs,
+            body_b64: base64::engine::general_purpose::STANDARD.encode(&body),
+            env: secrets,
+            role: auth.role.clone(),
+            request_id: auth.request_id.clone(),
+            jwt,
+        };
+
+        let output = run_guest(&wasm, &input).await?;
+
+        render_output(output)
+    })
+    .await
+}
+
+/// The result of running a guest, before it becomes an HTTP response.
+async fn run_guest(
+    wasm: &[u8],
+    input: &InvocationInput,
+) -> Result<InvocationOutput, SupaError> {
+    let input_bytes = serde_cbor_to_bytes(input)?;
+    let wasm = wasm.to_vec();
+    // The guardian compute runtime is synchronous and CPU-bound; run it in
+    // spawn_blocking so we do not stall the tokio scheduler.
+    let joined = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, GuestError> {
+        run_guest_blocking(&wasm, HANDLER_EXPORT, &input_bytes)
+    })
+    .await
+    .map_err(|e| SupaError::Internal(format!("guest runner join error: {e}")))?;
+
+    let bytes = match joined {
+        Ok(bytes) => bytes,
+        Err(GuestError::Boot(msg)) => {
+            return Err(SupaError::Internal(format!("__functions_boot::{msg}")));
+        }
+        Err(GuestError::Runtime(msg)) => {
+            return Err(SupaError::Internal(format!("__functions_runtime::{msg}")));
+        }
+    };
+
+    let out: InvocationOutput = serde_cbor_from_bytes(&bytes).map_err(|e| {
+        SupaError::Internal(format!("__functions_runtime::invalid output: {e}"))
+    })?;
+    Ok(out)
+}
+
+/// Errors distinguishing boot-time (compile/instantiate/missing export) from
+/// runtime (trap/deadline/fuel/etc.), so the invocation surface can render
+/// the correct `SUPA_COMPAT_FUNCTION_*` code.
+#[derive(Debug)]
+#[allow(dead_code)]
+enum GuestError {
+    Boot(String),
+    Runtime(String),
+}
+
+#[cfg(feature = "compute")]
+fn run_guest_blocking(
+    wasm: &[u8],
+    entrypoint: &str,
+    input: &[u8],
+) -> Result<Vec<u8>, GuestError> {
+    use crate::compute::runtime::{HostGrants, WasmRuntime};
+    use crate::compute::ResourceLimits;
+    use crate::compute::runtime::TaskError;
+
+    let runtime = WasmRuntime::new().map_err(|e| GuestError::Boot(e.to_string()))?;
+    let task = runtime
+        .compile(wasm)
+        .map_err(|e| GuestError::Boot(e.to_string()))?;
+    let limits = ResourceLimits {
+        max_memory_bytes: DEFAULT_MEMORY_BYTES,
+        fuel: DEFAULT_FUEL,
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+    };
+    let mut grants = HostGrants::default();
+    grants.log = true;
+    let result = runtime
+        .execute_with_host(&task, entrypoint, input, &limits, &grants)
+        .map_err(|e| match e {
+            TaskError::InvalidModule(m) => GuestError::Boot(format!("invalid module: {m}")),
+            TaskError::MissingExport(m) => GuestError::Boot(format!("missing export: {m}")),
+            TaskError::HostCapabilityDenied(m) => {
+                GuestError::Boot(format!("host capability denied: {m}"))
+            }
+            TaskError::FuelExhausted => GuestError::Runtime("fuel exhausted".into()),
+            TaskError::DeadlineExceeded => GuestError::Runtime("wall-clock deadline exceeded".into()),
+            TaskError::MemoryLimitExceeded => GuestError::Runtime("memory limit exceeded".into()),
+            TaskError::AbiViolation(m) => GuestError::Runtime(format!("abi violation: {m}")),
+            TaskError::Trapped(m) => GuestError::Runtime(format!("trap: {m}")),
+            TaskError::WasmUnavailable(m) => GuestError::Boot(format!("wasm unavailable: {m}")),
+            TaskError::Runtime(m) => GuestError::Runtime(m),
+        })?;
+    let _ = &result.metrics;
+    Ok(result.output)
+}
+
+/// Fallback runner when the `compute` feature is not enabled: no WASM sandbox
+/// is available. This preserves the module's compile-shape while making it
+/// clear the runtime substrate is off.
+#[cfg(not(feature = "compute"))]
+fn run_guest_blocking(
+    _wasm: &[u8],
+    _entrypoint: &str,
+    _input: &[u8],
+) -> Result<Vec<u8>, GuestError> {
+    Err(GuestError::Boot(
+        "the `compute` feature must be enabled to invoke functions".into(),
+    ))
+}
+
+fn render_output(output: InvocationOutput) -> Result<Response, SupaError> {
+    let status = StatusCode::from_u16(output.status)
+        .map_err(|_| SupaError::Internal(format!("_functions_runtime::bad status {}", output.status)))?;
+    let body_bytes = if output.body_b64.is_empty() {
+        Vec::new()
+    } else {
+        base64::engine::general_purpose::STANDARD
+            .decode(output.body_b64.as_bytes())
+            .map_err(|e| SupaError::Internal(format!("_functions_runtime::bad body base64: {e}")))?
+    };
+    let mut response = (status, body_bytes).into_response();
+    for (k, v) in output.headers {
+        let (Ok(name), Ok(value)) = (HeaderName::try_from(k), HeaderValue::try_from(v)) else {
+            continue;
+        };
+        response.headers_mut().insert(name, value);
+    }
+    Ok(response)
+}
+
+/// The standard Supabase Functions CORS preflight response — 204 with the
+/// echo of the caller's request headers. Matches how the deno-runtime CLI
+/// answers OPTIONS before dispatching to user code.
+fn cors_preflight_response(req_headers: &HeaderMap) -> Response {
+    let allow_headers = req_headers
+        .get("access-control-request-headers")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(
+            "authorization, x-client-info, apikey, content-type, x-supabase-api-version",
+        )
+        .to_string();
+    let mut resp = StatusCode::NO_CONTENT.into_response();
+    let h = resp.headers_mut();
+    h.insert(
+        "access-control-allow-origin",
+        HeaderValue::from_static("*"),
+    );
+    h.insert(
+        "access-control-allow-methods",
+        HeaderValue::from_static("POST, GET, PUT, PATCH, DELETE, OPTIONS"),
+    );
+    if let Ok(v) = HeaderValue::try_from(allow_headers) {
+        h.insert("access-control-allow-headers", v);
+    }
+    h.insert(
+        "access-control-max-age",
+        HeaderValue::from_static("86400"),
+    );
+    resp
+}
+
+// ---------------------------------------------------------------------------
+// Data-access helpers
+// ---------------------------------------------------------------------------
+
+async fn insert_code<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    id: Uuid,
+    wasm: &[u8],
+    now: chrono::DateTime<Utc>,
+) -> Result<(), SupaError> {
+    let sha = hex_sha256(wasm);
+    run_sql_as(
+        &state.db,
+        auth,
+        "INSERT INTO functions._code \
+         (function_id, body, content_sha256, size_bytes, updated_at) \
+         VALUES ($1, $2, $3, $4, $5)",
+        vec![
+            SqlValue::Uuid(id),
+            SqlValue::Bytea(wasm.to_vec()),
+            SqlValue::Text(sha),
+            SqlValue::Int8(wasm.len() as i64),
+            SqlValue::Timestamptz(now),
+        ],
+    )
+    .await
+    .map_err(SupaError::Sql)?;
+    Ok(())
+}
+
+async fn replace_code<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    id: Uuid,
+    wasm: &[u8],
+    now: chrono::DateTime<Utc>,
+) -> Result<(), SupaError> {
+    run_sql_as(
+        &state.db,
+        auth,
+        "DELETE FROM functions._code WHERE function_id = $1",
+        vec![SqlValue::Uuid(id)],
+    )
+    .await
+    .map_err(SupaError::Sql)?;
+    insert_code(state, auth, id, wasm, now).await
+}
+
+async fn load_code<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    id: Uuid,
+) -> Result<Option<Vec<u8>>, SupaError> {
+    let result = run_sql_as(
+        &state.db,
+        auth,
+        "SELECT body FROM functions._code WHERE function_id = $1",
+        vec![SqlValue::Uuid(id)],
+    )
+    .await
+    .map_err(SupaError::Sql)?;
+    let ExecResult::Rows { rows, .. } = result else {
+        return Ok(None);
+    };
+    let Some(row) = rows.into_iter().next() else {
+        return Ok(None);
+    };
+    match row.into_iter().next() {
+        Some(SqlValue::Bytea(bytes)) => Ok(Some(bytes)),
+        Some(SqlValue::Null) => Ok(None),
+        _ => Err(SupaError::Internal(
+            "function body column is not bytea".into(),
+        )),
+    }
+}
+
+async fn load_secrets<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    id: Uuid,
+) -> Result<Vec<(String, String)>, SupaError> {
+    let result = run_sql_as(
+        &state.db,
+        auth,
+        "SELECT name, value FROM functions.secrets WHERE function_id = $1 ORDER BY name",
+        vec![SqlValue::Uuid(id)],
+    )
+    .await
+    .map_err(SupaError::Sql)?;
+    let ExecResult::Rows { rows, .. } = result else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut it = row.into_iter();
+        let name = match it.next() {
+            Some(SqlValue::Text(s)) => s,
+            _ => continue,
+        };
+        let value = match it.next() {
+            Some(SqlValue::Text(s)) => s,
+            _ => continue,
+        };
+        out.push((name, value));
+    }
+    Ok(out)
+}
+
+async fn load_function_row<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    slug: &str,
+) -> Result<Option<Json>, SupaError> {
+    let result = run_sql_as(
+        &state.db,
+        auth,
+        &format!("SELECT {FUNCTION_COLUMNS} FROM functions.functions WHERE slug = $1"),
+        vec![SqlValue::Text(slug.to_string())],
+    )
+    .await
+    .map_err(SupaError::Sql)?;
+    let objs = result_objects(result)?;
+    Ok(objs.into_iter().next())
+}
+
+async fn fetch_one_function<S: RelationalStorage + 'static>(
+    state: &AppState<S>,
+    auth: &AuthContext,
+    slug: &str,
+) -> Result<Json, SupaError> {
+    load_function_row(state, auth, slug)
+        .await?
+        .ok_or_else(|| SupaError::Internal(format!("function \"{slug}\" vanished after write")))
+}
+
+fn extract_id(row: &Json) -> Result<Uuid, SupaError> {
+    row.get("id")
+        .and_then(Json::as_str)
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .ok_or_else(|| SupaError::Internal("function row missing id".into()))
+}
+
+fn extract_bool(row: &Json, key: &str) -> Option<bool> {
+    row.get(key).and_then(Json::as_bool)
+}
+
+// ---------------------------------------------------------------------------
+// Small utilities
+// ---------------------------------------------------------------------------
+
+fn require_service_role(auth: &AuthContext) -> Result<(), SupaError> {
+    if auth.is_service_role() {
+        Ok(())
+    } else {
+        Err(SupaError::Forbidden("this admin route"))
+    }
+}
+
+/// Build a service-role-shaped copy of the caller's `AuthContext`, preserving
+/// their claims and request-id — used for internal metadata lookups on the
+/// invocation path that must bypass the RLS-default-deny on `functions.*`.
+fn as_service_role(auth: &AuthContext) -> AuthContext {
+    let mut clone = auth.clone();
+    clone.role = "service_role".into();
+    clone
+}
+
+fn validate_slug(slug: &str) -> Result<(), SupaError> {
+    let ok = !slug.is_empty()
+        && slug.len() <= 128
+        && slug
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_');
+    if ok {
+        Ok(())
+    } else {
+        Err(SupaError::BadRequest(format!(
+            "invalid function slug: \"{slug}\" (allowed: [A-Za-z0-9_-], max 128)"
+        )))
+    }
+}
+
+fn validate_secret_name(name: &str) -> Result<(), SupaError> {
+    let ok = !name.is_empty()
+        && name.len() <= 128
+        && name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if ok {
+        Ok(())
+    } else {
+        Err(SupaError::BadRequest(format!(
+            "invalid secret name: \"{name}\" (must match [A-Za-z_][A-Za-z0-9_]*, max 128)"
+        )))
+    }
+}
+
+fn decode_wasm(b64: &str) -> Result<Vec<u8>, SupaError> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64.as_bytes())
+        .map_err(|e| SupaError::BadRequest(format!("wasm body is not valid base64: {e}")))?;
+    if bytes.len() > MAX_WASM_BUNDLE_BYTES {
+        return Err(SupaError::BadRequest(format!(
+            "wasm body exceeds {MAX_WASM_BUNDLE_BYTES} bytes ({} bytes)",
+            bytes.len()
+        )));
+    }
+    validate_wasm_magic(&bytes)?;
+    Ok(bytes)
+}
+
+fn validate_wasm_magic(bytes: &[u8]) -> Result<(), SupaError> {
+    const WASM_MAGIC: &[u8] = b"\0asm";
+    if bytes.len() < 8 || &bytes[..4] != WASM_MAGIC {
+        return Err(SupaError::BadRequest(
+            "body is not a WebAssembly module (missing \\0asm magic)".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    #[cfg(feature = "sql")]
+    {
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(bytes);
+        return hex::encode(digest);
+    }
+    #[cfg(not(feature = "sql"))]
+    {
+        // The `supabase` feature implies `sql`, which pulls in sha2, but keep
+        // the fallback so a hypothetical feature-shuffled build still builds.
+        format!("blake3-{}", blake3::hash(bytes).to_hex())
+    }
+}
+
+fn bearer_from(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            v.strip_prefix("Bearer ")
+                .or_else(|| v.strip_prefix("bearer "))
+                .or_else(|| v.strip_prefix("BEARER "))
+                .map(str::trim)
+                .map(String::from)
+        })
+}
+
+/// Encode a value as CBOR — bytes-safe transport for guest input.
+fn serde_cbor_to_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, SupaError> {
+    let mut out = Vec::with_capacity(256);
+    ciborium::ser::into_writer(value, &mut out)
+        .map_err(|e| SupaError::Internal(format!("_functions_runtime::cbor encode: {e}")))?;
+    Ok(out)
+}
+
+fn serde_cbor_from_bytes<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, SupaError> {
+    ciborium::de::from_reader(bytes)
+        .map_err(|e| SupaError::Internal(format!("_functions_runtime::cbor decode: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// ExecResult → JSON (mirrors the storage.rs helper; kept local to avoid
+// pulling private helpers across modules)
+// ---------------------------------------------------------------------------
+
+/// Convert an `ExecResult` into an array of JSON objects.
+fn result_objects(result: ExecResult) -> Result<Vec<Json>, SupaError> {
+    match result {
+        ExecResult::Rows { fields, rows } => {
+            let mut out = Vec::with_capacity(rows.len());
+            for row in rows {
+                let mut obj = Map::with_capacity(fields.len());
+                for (field, value) in fields.iter().zip(row.into_iter()) {
+                    obj.insert(field.name.clone(), value_to_json(value));
+                }
+                out.push(Json::Object(obj));
+            }
+            Ok(out)
+        }
+        ExecResult::Command { .. } => Ok(Vec::new()),
+    }
+}
+
+/// Local, self-contained SqlValue → JSON rendering. Mirrors the shape of the
+/// REST module's helper without depending on it, since this feature-slice
+/// keeps its module surface minimal.
+fn value_to_json(v: SqlValue) -> Json {
+    match v {
+        SqlValue::Null => Json::Null,
+        SqlValue::Bool(b) => Json::Bool(b),
+        SqlValue::Int2(n) => Json::from(n),
+        SqlValue::Int4(n) => Json::from(n),
+        SqlValue::Int8(n) => Json::from(n),
+        SqlValue::Float4(f) => serde_json::Number::from_f64(f as f64)
+            .map(Json::Number)
+            .unwrap_or(Json::Null),
+        SqlValue::Float8(f) => serde_json::Number::from_f64(f)
+            .map(Json::Number)
+            .unwrap_or(Json::Null),
+        SqlValue::Numeric(d) => Json::String(d.to_string()),
+        SqlValue::Text(s) => Json::String(s),
+        SqlValue::Citext(s) => Json::String(s),
+        SqlValue::Bytea(b) => {
+            Json::String(base64::engine::general_purpose::STANDARD.encode(b))
+        }
+        SqlValue::Uuid(u) => Json::String(u.to_string()),
+        SqlValue::Date(d) => Json::String(d.to_string()),
+        SqlValue::Time(t) => Json::String(t.to_string()),
+        SqlValue::Timestamp(t) => Json::String(t.to_string()),
+        SqlValue::Timestamptz(t) => Json::String(t.to_rfc3339()),
+        SqlValue::Json(j) => j,
+        SqlValue::Array(items) => Json::Array(items.into_iter().map(value_to_json).collect()),
+        SqlValue::Vector(v) => Json::Array(
+            v.into_iter()
+                .filter_map(|f| serde_json::Number::from_f64(f as f64).map(Json::Number))
+                .collect(),
+        ),
+        SqlValue::HStore(m) => {
+            let mut obj = Map::with_capacity(m.len());
+            for (k, v) in m {
+                obj.insert(k, v.map(Json::String).unwrap_or(Json::Null));
+            }
+            Json::Object(obj)
+        }
+        SqlValue::Ltree(s) => Json::String(s),
+        SqlValue::Cube { ll, ur } => json!({ "ll": ll, "ur": ur }),
+        SqlValue::TsVector(_) | SqlValue::TsQuery(_) => Json::Null,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error-driven response helper (mirrors storage.rs's `run` helper)
+// ---------------------------------------------------------------------------
+
+async fn run<F>(fut: F) -> Response
+where
+    F: std::future::Future<Output = Result<Response, SupaError>>,
+{
+    fut.await.unwrap_or_else(functions_error_from)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_validation() {
+        assert!(validate_slug("hello-world").is_ok());
+        assert!(validate_slug("hello_world_2").is_ok());
+        assert!(validate_slug("Hello123").is_ok());
+        assert!(validate_slug("").is_err());
+        assert!(validate_slug("has space").is_err());
+        assert!(validate_slug("has/slash").is_err());
+        assert!(validate_slug(&"a".repeat(129)).is_err());
+    }
+
+    #[test]
+    fn secret_name_validation() {
+        assert!(validate_secret_name("MY_ENV").is_ok());
+        assert!(validate_secret_name("_leading").is_ok());
+        assert!(validate_secret_name("").is_err());
+        assert!(validate_secret_name("1leading").is_err());
+        assert!(validate_secret_name("has-dash").is_err());
+    }
+
+    #[test]
+    fn wasm_magic_check() {
+        assert!(validate_wasm_magic(b"\0asm\x01\x00\x00\x00").is_ok());
+        assert!(validate_wasm_magic(b"not-wasm").is_err());
+        assert!(validate_wasm_magic(b"").is_err());
+    }
+
+    #[test]
+    fn error_shape_stable() {
+        let resp = functions_error(FunctionsErrorCode::NotFound, "no such fn");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn cbor_round_trip() {
+        let input = InvocationInput {
+            method: "POST".into(),
+            url: "http://x/functions/v1/hi".into(),
+            path: "/functions/v1/hi".into(),
+            query: String::new(),
+            headers: vec![("x".into(), "1".into())],
+            body_b64: base64::engine::general_purpose::STANDARD.encode(b"hello"),
+            env: vec![("SECRET".into(), "s3cret".into())],
+            role: "anon".into(),
+            request_id: "req-1".into(),
+            jwt: String::new(),
+        };
+        let bytes = serde_cbor_to_bytes(&input).unwrap();
+        let back: InvocationInput = serde_cbor_from_bytes(&bytes).unwrap();
+        assert_eq!(back.method, "POST");
+        assert_eq!(back.headers, vec![("x".to_string(), "1".to_string())]);
+    }
+
+    #[test]
+    fn default_status_is_200() {
+        let out: InvocationOutput = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(out.status, 200);
+        assert!(out.body_b64.is_empty());
+    }
+}

--- a/src/supabase/functions.rs
+++ b/src/supabase/functions.rs
@@ -901,10 +901,7 @@ async fn invoke_function<S: RelationalStorage + 'static>(
 }
 
 /// The result of running a guest, before it becomes an HTTP response.
-async fn run_guest(
-    wasm: &[u8],
-    input: &InvocationInput,
-) -> Result<InvocationOutput, SupaError> {
+async fn run_guest(wasm: &[u8], input: &InvocationInput) -> Result<InvocationOutput, SupaError> {
     let input_bytes = serde_cbor_to_bytes(input)?;
     let wasm = wasm.to_vec();
     // The guardian compute runtime is synchronous and CPU-bound; run it in
@@ -925,9 +922,8 @@ async fn run_guest(
         }
     };
 
-    let out: InvocationOutput = serde_cbor_from_bytes(&bytes).map_err(|e| {
-        SupaError::Internal(format!("__functions_runtime::invalid output: {e}"))
-    })?;
+    let out: InvocationOutput = serde_cbor_from_bytes(&bytes)
+        .map_err(|e| SupaError::Internal(format!("__functions_runtime::invalid output: {e}")))?;
     Ok(out)
 }
 
@@ -942,14 +938,10 @@ enum GuestError {
 }
 
 #[cfg(feature = "compute")]
-fn run_guest_blocking(
-    wasm: &[u8],
-    entrypoint: &str,
-    input: &[u8],
-) -> Result<Vec<u8>, GuestError> {
-    use crate::compute::runtime::{HostGrants, WasmRuntime};
+fn run_guest_blocking(wasm: &[u8], entrypoint: &str, input: &[u8]) -> Result<Vec<u8>, GuestError> {
     use crate::compute::ResourceLimits;
     use crate::compute::runtime::TaskError;
+    use crate::compute::runtime::{HostGrants, WasmRuntime};
 
     let runtime = WasmRuntime::new().map_err(|e| GuestError::Boot(e.to_string()))?;
     let task = runtime
@@ -960,8 +952,10 @@ fn run_guest_blocking(
         fuel: DEFAULT_FUEL,
         timeout_ms: DEFAULT_TIMEOUT_MS,
     };
-    let mut grants = HostGrants::default();
-    grants.log = true;
+    let grants = HostGrants {
+        log: true,
+        ..HostGrants::default()
+    };
     let result = runtime
         .execute_with_host(&task, entrypoint, input, &limits, &grants)
         .map_err(|e| match e {
@@ -971,7 +965,9 @@ fn run_guest_blocking(
                 GuestError::Boot(format!("host capability denied: {m}"))
             }
             TaskError::FuelExhausted => GuestError::Runtime("fuel exhausted".into()),
-            TaskError::DeadlineExceeded => GuestError::Runtime("wall-clock deadline exceeded".into()),
+            TaskError::DeadlineExceeded => {
+                GuestError::Runtime("wall-clock deadline exceeded".into())
+            }
             TaskError::MemoryLimitExceeded => GuestError::Runtime("memory limit exceeded".into()),
             TaskError::AbiViolation(m) => GuestError::Runtime(format!("abi violation: {m}")),
             TaskError::Trapped(m) => GuestError::Runtime(format!("trap: {m}")),
@@ -997,8 +993,9 @@ fn run_guest_blocking(
 }
 
 fn render_output(output: InvocationOutput) -> Result<Response, SupaError> {
-    let status = StatusCode::from_u16(output.status)
-        .map_err(|_| SupaError::Internal(format!("_functions_runtime::bad status {}", output.status)))?;
+    let status = StatusCode::from_u16(output.status).map_err(|_| {
+        SupaError::Internal(format!("_functions_runtime::bad status {}", output.status))
+    })?;
     let body_bytes = if output.body_b64.is_empty() {
         Vec::new()
     } else {
@@ -1023,16 +1020,11 @@ fn cors_preflight_response(req_headers: &HeaderMap) -> Response {
     let allow_headers = req_headers
         .get("access-control-request-headers")
         .and_then(|v| v.to_str().ok())
-        .unwrap_or(
-            "authorization, x-client-info, apikey, content-type, x-supabase-api-version",
-        )
+        .unwrap_or("authorization, x-client-info, apikey, content-type, x-supabase-api-version")
         .to_string();
     let mut resp = StatusCode::NO_CONTENT.into_response();
     let h = resp.headers_mut();
-    h.insert(
-        "access-control-allow-origin",
-        HeaderValue::from_static("*"),
-    );
+    h.insert("access-control-allow-origin", HeaderValue::from_static("*"));
     h.insert(
         "access-control-allow-methods",
         HeaderValue::from_static("POST, GET, PUT, PATCH, DELETE, OPTIONS"),
@@ -1040,10 +1032,7 @@ fn cors_preflight_response(req_headers: &HeaderMap) -> Response {
     if let Ok(v) = HeaderValue::try_from(allow_headers) {
         h.insert("access-control-allow-headers", v);
     }
-    h.insert(
-        "access-control-max-age",
-        HeaderValue::from_static("86400"),
-    );
+    h.insert("access-control-max-age", HeaderValue::from_static("86400"));
     resp
 }
 
@@ -1234,9 +1223,7 @@ fn validate_secret_name(name: &str) -> Result<(), SupaError> {
     let ok = !name.is_empty()
         && name.len() <= 128
         && name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
     if ok {
         Ok(())
     } else {
@@ -1275,7 +1262,7 @@ fn hex_sha256(bytes: &[u8]) -> String {
     {
         use sha2::{Digest, Sha256};
         let digest = Sha256::digest(bytes);
-        return hex::encode(digest);
+        hex::encode(digest)
     }
     #[cfg(not(feature = "sql"))]
     {
@@ -1323,7 +1310,7 @@ fn result_objects(result: ExecResult) -> Result<Vec<Json>, SupaError> {
             let mut out = Vec::with_capacity(rows.len());
             for row in rows {
                 let mut obj = Map::with_capacity(fields.len());
-                for (field, value) in fields.iter().zip(row.into_iter()) {
+                for (field, value) in fields.iter().zip(row) {
                     obj.insert(field.name.clone(), value_to_json(value));
                 }
                 out.push(Json::Object(obj));
@@ -1353,9 +1340,7 @@ fn value_to_json(v: SqlValue) -> Json {
         SqlValue::Numeric(d) => Json::String(d.to_string()),
         SqlValue::Text(s) => Json::String(s),
         SqlValue::Citext(s) => Json::String(s),
-        SqlValue::Bytea(b) => {
-            Json::String(base64::engine::general_purpose::STANDARD.encode(b))
-        }
+        SqlValue::Bytea(b) => Json::String(base64::engine::general_purpose::STANDARD.encode(b)),
         SqlValue::Uuid(u) => Json::String(u.to_string()),
         SqlValue::Date(d) => Json::String(d.to_string()),
         SqlValue::Time(t) => Json::String(t.to_string()),

--- a/src/supabase/gateway.rs
+++ b/src/supabase/gateway.rs
@@ -36,6 +36,8 @@ pub struct AppState<S: RelationalStorage> {
     pub schema_ready: Arc<tokio::sync::OnceCell<()>>,
     /// One-shot guard so the `storage` schema is bootstrapped on first use.
     pub storage_ready: Arc<tokio::sync::OnceCell<()>>,
+    /// One-shot guard so the `functions` schema is bootstrapped on first use.
+    pub functions_ready: Arc<tokio::sync::OnceCell<()>>,
     /// Shared realtime state (the broadcast bus between websocket subscribers
     /// and the id generator for connections / bindings).
     pub realtime: Arc<crate::supabase::realtime::RealtimeShared>,
@@ -49,6 +51,7 @@ impl<S: RelationalStorage> Clone for AppState<S> {
             config: self.config.clone(),
             schema_ready: self.schema_ready.clone(),
             storage_ready: self.storage_ready.clone(),
+            functions_ready: self.functions_ready.clone(),
             realtime: self.realtime.clone(),
         }
     }
@@ -66,6 +69,7 @@ impl<S: RelationalStorage> AppState<S> {
             config: Arc::new(config),
             schema_ready: Arc::new(tokio::sync::OnceCell::new()),
             storage_ready: Arc::new(tokio::sync::OnceCell::new()),
+            functions_ready: Arc::new(tokio::sync::OnceCell::new()),
             realtime: Arc::new(crate::supabase::realtime::RealtimeShared::new()),
         }
     }
@@ -134,6 +138,9 @@ pub fn build_router<S: RelationalStorage + 'static>(state: AppState<S>) -> Route
         // the handlers.
         .nest("/pg-meta", crate::supabase::pg_meta::router::<S>())
         .nest("/platform/pg-meta", crate::supabase::pg_meta::router::<S>())
+        // Functions: invocation + admin CRUD, both apikey-verified. Admin
+        // handlers additionally require service_role.
+        .nest("/functions/v1", crate::supabase::functions::router::<S>())
         .layer(apikey_layer.clone());
 
     // Storage: authenticated routes behind the apikey layer, plus the
@@ -150,21 +157,9 @@ pub fn build_router<S: RelationalStorage + 'static>(state: AppState<S>) -> Route
         // Realtime: browsers cannot set headers on websocket connects, so the
         // apikey arrives as a query parameter, verified inside the handler.
         .nest("/realtime/v1", crate::supabase::realtime::router::<S>())
-        .merge(stub_router::<S>())
         .route("/health", any(health))
         .layer(axum::middleware::from_fn(request_id))
         .with_state(state)
-}
-
-/// The not-yet-implemented Kong services. Each returns a typed `501` (never a
-/// bare 404 and never fake success). These sit outside the apikey layer so the
-/// answer is a clear "not implemented" regardless of credentials.
-fn stub_router<S: RelationalStorage + 'static>() -> Router<AppState<S>> {
-    Router::new().route("/functions/v1/{*rest}", any(|| not_impl("FUNCTIONS")))
-}
-
-async fn not_impl(service: &'static str) -> Response {
-    SupaError::NotImplemented(service).into_response()
 }
 
 async fn health() -> Response {

--- a/src/supabase/mod.rs
+++ b/src/supabase/mod.rs
@@ -9,10 +9,13 @@
 //! Implemented end-to-end: **REST** (PostgREST-compatible), **Auth**
 //! (GoTrue-compatible), **Storage** (storage-api-compatible, bytes in a
 //! replicated `bytea` table), **postgres-meta** (what Supabase Studio talks
-//! to), **Realtime** (Phoenix-protocol websocket) and **GraphQL**
-//! (pg_graphql-compatible schema reflection over the `public` schema). The
-//! remaining Kong service (functions) returns a typed `501 Not Implemented`
-//! error — never a bare 404 and never fake success.
+//! to), **Realtime** (Phoenix-protocol websocket), **GraphQL**
+//! (pg_graphql-compatible schema reflection over the `public` schema), and
+//! **Functions** (Supabase Edge Functions-compatible, backed by the Guardian
+//! Compute WASM sandbox when the `compute` feature is on — otherwise the
+//! service returns a typed `SUPA_COMPAT_FUNCTION_BOOT_ERROR` on invocation
+//! and admin CRUD still works so functions can be deployed for a later
+//! runtime).
 //!
 //! ## Scouted seams (Stage 0)
 //!
@@ -51,6 +54,9 @@
 //! * Crypto: `bcrypt` (from the pgcrypto work) hashes/verifies passwords;
 //!   `hmac` + `sha2` + `base64` (already in-tree for `sql`) implement HS256 JWTs
 //!   from scratch in [`jwt`] — no `jsonwebtoken` dependency added.
+//! * When the `compute` feature is also on, [`crate::compute::WasmRuntime`]
+//!   backs the Supabase Functions runtime: deployed WebAssembly modules run
+//!   under the same sandbox as delegated Guardian Compute tasks.
 //!
 //! ## Architecture
 //!
@@ -70,7 +76,8 @@
 //!     ├─ /storage/v1/* → storage.rs  → Session(role) → storage.* tables (RLS)
 //!     ├─ /pg-meta/*    → pg_meta.rs  → catalog + pg_catalog views (service_role)
 //!     ├─ /realtime/v1/websocket → realtime.rs → Phoenix ws + change hook
-//!     └─ /functions    → 501 typed
+//!     └─ /functions/v1/* → functions.rs → WASM sandbox (invocation)
+//!                                          + service_role admin CRUD
 //! ```
 //!
 //! Each request opens a fresh [`Session`] bound to the resolved role. A single
@@ -79,6 +86,7 @@
 
 pub mod auth;
 pub mod error;
+pub mod functions;
 pub mod gateway;
 pub mod graphql;
 pub mod jwt;

--- a/tests/supabase_functions.rs
+++ b/tests/supabase_functions.rs
@@ -1,0 +1,721 @@
+//! Integration tests for the Supabase Functions compatibility layer.
+//!
+//! Drives the axum `Router` directly with `tower::ServiceExt::oneshot` over a
+//! `MemoryStorage`-backed `Database` — no ports are bound and no WASM is
+//! executed here. WASM-invocation tests belong under `--features
+//! "supabase,compute"` and are gated separately.
+
+#![cfg(feature = "supabase")]
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderMap, Request, StatusCode};
+use base64::Engine as _;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use guardian_db::sql::MemoryStorage;
+use guardian_db::sql::engine::Database;
+use guardian_db::supabase::project::ProjectKeys;
+use guardian_db::supabase::{AppState, ServiceConfig, SupabaseCompatProject, build_router};
+
+const TEST_SECRET: &str = "integration-test-jwt-secret-value-0123456789";
+const IAT: i64 = 1_700_000_000;
+
+struct Harness {
+    app: Router,
+    anon: String,
+    service: String,
+    #[allow(dead_code)]
+    db: Arc<Database<MemoryStorage>>,
+}
+
+async fn harness() -> Harness {
+    let db = Arc::new(Database::new(Arc::new(MemoryStorage::new()), "app"));
+    let keys = ProjectKeys::from_secret(TEST_SECRET, IAT).unwrap();
+    let anon = keys.anon_key.clone();
+    let service = keys.service_role_key.clone();
+    let project =
+        SupabaseCompatProject::shell("app", "http://127.0.0.1:54321", keys, chrono::Utc::now());
+    let state = AppState::new(db.clone(), project, ServiceConfig::default());
+    let app = build_router(state);
+    Harness {
+        app,
+        anon,
+        service,
+        db,
+    }
+}
+
+async fn call(
+    app: &Router,
+    method: &str,
+    uri: &str,
+    apikey: Option<&str>,
+    bearer: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, HeaderMap, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(k) = apikey {
+        builder = builder.header("apikey", k);
+    }
+    if let Some(b) = bearer {
+        builder = builder.header("authorization", format!("Bearer {b}"));
+    }
+    let req = match body {
+        Some(v) => builder
+            .header("content-type", "application/json")
+            .body(Body::from(v.to_string()))
+            .unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
+    };
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, headers, json)
+}
+
+async fn call_raw(
+    app: &Router,
+    method: &str,
+    uri: &str,
+    headers: &[(&str, &str)],
+    body: Option<Vec<u8>>,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    for (k, v) in headers {
+        builder = builder.header(*k, *v);
+    }
+    let req = builder
+        .body(body.map(Body::from).unwrap_or_else(Body::empty))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    (status, headers, bytes.to_vec())
+}
+
+/// A minimal valid WASM module: magic + version + one empty type section.
+/// It has no exports so instantiation succeeds but invoking `handler` fails
+/// with `MissingExport` — enough to prove the deploy path stores/retrieves
+/// the bundle and boot-time validation runs.
+fn minimal_wasm() -> Vec<u8> {
+    // \0asm, version 1
+    b"\0asm\x01\x00\x00\x00".to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// Admin CRUD
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn admin_requires_service_role() {
+    let h = harness().await;
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions",
+        Some(&h.anon),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_FORBIDDEN");
+}
+
+#[tokio::test]
+async fn admin_list_empty() {
+    let h = harness().await;
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn admin_create_and_get() {
+    let h = harness().await;
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "hello", "name": "Hello world", "verify_jwt": false })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(body["slug"], "hello");
+    assert_eq!(body["verify_jwt"], false);
+    assert_eq!(body["status"], "PENDING");
+    assert_eq!(body["version"], 1);
+
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/hello",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["slug"], "hello");
+
+    let (status, _, list) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = list.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["slug"], "hello");
+}
+
+#[tokio::test]
+async fn admin_create_duplicate_slug_conflict() {
+    let h = harness().await;
+    let (status, _, _) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "dup" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "dup" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BAD_REQUEST");
+}
+
+#[tokio::test]
+async fn admin_bad_slug_is_rejected() {
+    let h = harness().await;
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "has space" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BAD_REQUEST");
+}
+
+#[tokio::test]
+async fn admin_bad_wasm_body_is_rejected() {
+    let h = harness().await;
+    let b64_junk = base64::engine::general_purpose::STANDARD.encode(b"not wasm");
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "bad", "body": b64_junk })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BAD_REQUEST");
+}
+
+#[tokio::test]
+async fn admin_deploy_body_via_put() {
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "hello" })),
+    )
+    .await;
+
+    let wasm = minimal_wasm();
+    let (status, _, body) = call_raw(
+        &h.app,
+        "PUT",
+        "/functions/v1/_admin/functions/hello/body",
+        &[
+            ("apikey", h.service.as_str()),
+            ("content-type", "application/wasm"),
+        ],
+        Some(wasm.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let parsed: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["status"], "ACTIVE");
+    assert_eq!(parsed["version"], 2);
+
+    let (status, _, got) = call_raw(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/hello/body",
+        &[("apikey", h.service.as_str())],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(got, wasm);
+}
+
+#[tokio::test]
+async fn admin_update_metadata() {
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "hello", "verify_jwt": true })),
+    )
+    .await;
+    let (status, _, body) = call(
+        &h.app,
+        "PATCH",
+        "/functions/v1/_admin/functions/hello",
+        Some(&h.service),
+        None,
+        Some(json!({ "name": "Renamed", "verify_jwt": false })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["name"], "Renamed");
+    assert_eq!(body["verify_jwt"], false);
+    assert_eq!(body["version"], 1);
+}
+
+#[tokio::test]
+async fn admin_delete_function() {
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "gone" })),
+    )
+    .await;
+    let (status, _, _) = call(
+        &h.app,
+        "DELETE",
+        "/functions/v1/_admin/functions/gone",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/gone",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_NOT_FOUND");
+}
+
+// ---------------------------------------------------------------------------
+// Secrets
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn secret_lifecycle() {
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "envy" })),
+    )
+    .await;
+
+    // Empty list first.
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/envy/secrets",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.as_array().unwrap().is_empty());
+
+    // Upsert.
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions/envy/secrets",
+        Some(&h.service),
+        None,
+        Some(json!({ "name": "OPENAI_KEY", "value": "sk-abc123" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["name"], "OPENAI_KEY");
+
+    // List (values never surfaced).
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/envy/secrets",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "OPENAI_KEY");
+    assert!(arr[0].get("value").is_none(), "secret value must not leak");
+
+    // Delete single.
+    let (status, _, _) = call(
+        &h.app,
+        "DELETE",
+        "/functions/v1/_admin/functions/envy/secrets/OPENAI_KEY",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _, body) = call(
+        &h.app,
+        "GET",
+        "/functions/v1/_admin/functions/envy/secrets",
+        Some(&h.service),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn secret_bad_name_rejected() {
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "envy2" })),
+    )
+    .await;
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions/envy2/secrets",
+        Some(&h.service),
+        None,
+        Some(json!({ "name": "1BADNAME", "value": "x" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BAD_REQUEST");
+}
+
+// ---------------------------------------------------------------------------
+// Invocation (metadata / gating; WASM execution is gated behind `compute`)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn invoke_unknown_slug_is_404_typed() {
+    let h = harness().await;
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/never-deployed",
+        Some(&h.anon),
+        None,
+        Some(json!({ "hi": "there" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_NOT_FOUND");
+}
+
+#[tokio::test]
+async fn invoke_verify_jwt_requires_bearer() {
+    let h = harness().await;
+    // Deploy with verify_jwt=true and no body (so it never runs; we only
+    // exercise the JWT gate).
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({ "slug": "locked", "verify_jwt": true })),
+    )
+    .await;
+
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/locked",
+        Some(&h.anon),
+        None, // no bearer
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_FORBIDDEN");
+}
+
+#[tokio::test]
+async fn invoke_options_is_cors_preflight() {
+    let h = harness().await;
+    // No apikey needed for preflight? Apikey middleware still gates the
+    // whole nested router, so include it. Browsers do skip auth on preflight
+    // via the OPTIONS-without-credentials shape, and Supabase-hosted platform
+    // sits behind Kong which passes OPTIONS through — our layer is stricter
+    // by design (documented) and still returns the correct preflight body
+    // once authenticated.
+    let (status, headers, _) = call_raw(
+        &h.app,
+        "OPTIONS",
+        "/functions/v1/hello",
+        &[
+            ("apikey", h.anon.as_str()),
+            ("access-control-request-method", "POST"),
+            ("access-control-request-headers", "authorization, apikey"),
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(headers.get("access-control-allow-methods").is_some());
+    assert!(headers.get("access-control-allow-headers").is_some());
+}
+
+#[tokio::test]
+async fn invoke_no_body_is_500_boot_error_without_compute() {
+    // With no `compute` feature the runtime substrate is off, and
+    // `run_guest_blocking` returns a boot error. But because the function
+    // has no deployed body, we hit the 404 path first — which is the
+    // correct behavior. Exercise both: deploy with an empty stub body,
+    // then invoke.
+    let h = harness().await;
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({
+            "slug": "noop",
+            "verify_jwt": false,
+            "body": base64::engine::general_purpose::STANDARD.encode(&minimal_wasm())
+        })),
+    )
+    .await;
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/noop",
+        Some(&h.anon),
+        None,
+        Some(json!({})),
+    )
+    .await;
+    // Without `compute` this returns a boot error; with `compute` the
+    // minimal module lacks the `handler` export and gets a boot error too.
+    // Either way, the wire shape is `SUPA_COMPAT_FUNCTION_BOOT_ERROR`.
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BOOT_ERROR");
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end WASM execution (requires `compute` feature)
+// ---------------------------------------------------------------------------
+
+/// A hand-crafted WASM guest that implements the full Functions ABI: `memory`,
+/// `gdb_alloc(len) -> i32`, and `handler(ptr, len) -> i64` returning the
+/// packed `(out_ptr << 32) | out_len` for a pre-baked CBOR-encoded
+/// `InvocationOutput { status: 200, headers: [], body_b64: <base64 of "hi
+/// from wasm"> }`.
+///
+/// The output CBOR is generated at test-authoring time with `ciborium` and
+/// embedded as raw bytes in a `data` section — the guest just returns its
+/// stable offset and length. Kept minimal on purpose: a real deployed
+/// function would parse the input envelope, do work, and marshal its own
+/// output; this proves the wire glue works end-to-end without pulling in a
+/// full Rust WASM build for the test.
+#[cfg(feature = "compute")]
+fn echo_wasm() -> Vec<u8> {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Out<'a> {
+        status: u16,
+        headers: &'a [(String, String)],
+        body_b64: String,
+    }
+
+    let body_b64 = base64::engine::general_purpose::STANDARD.encode(b"hi from wasm");
+    let out = Out {
+        status: 200,
+        headers: &[],
+        body_b64,
+    };
+    let mut cbor = Vec::new();
+    ciborium::ser::into_writer(&out, &mut cbor).unwrap();
+    // The output CBOR sits at a fixed offset (2048); alloc bumps from 4096
+    // so nothing overwrites it. `handler` returns (2048 << 32) | len.
+    let offset: u32 = 2048;
+    let len: u32 = cbor.len() as u32;
+    let packed: u64 = ((offset as u64) << 32) | (len as u64);
+    // Encode `packed` as a WAT `i64.const` literal (decimal is fine).
+    let hex_bytes: String = cbor
+        .iter()
+        .map(|b| format!("\\{:02x}", b))
+        .collect::<Vec<_>>()
+        .join("");
+    let wat = format!(
+        r#"
+        (module
+          (memory (export "memory") 1)
+          (data (i32.const {offset}) "{bytes}")
+          (global $next (mut i32) (i32.const 4096))
+          (func (export "gdb_alloc") (param $len i32) (result i32)
+            (local $ptr i32)
+            (local.set $ptr (global.get $next))
+            (global.set $next (i32.add (global.get $next) (local.get $len)))
+            (local.get $ptr))
+          (func (export "handler") (param $ptr i32) (param $len i32) (result i64)
+            (i64.const {packed})))
+        "#,
+        offset = offset,
+        bytes = hex_bytes,
+        packed = packed,
+    );
+    wat::parse_str(&wat).expect("valid WAT for echo guest")
+}
+
+#[cfg(feature = "compute")]
+#[tokio::test]
+async fn invoke_end_to_end_wasm_returns_response() {
+    let h = harness().await;
+    let wasm = echo_wasm();
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&wasm);
+    let (status, _, _) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({
+            "slug": "wasm-echo",
+            "verify_jwt": false,
+            "body": b64
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, _, body_bytes) = call_raw(
+        &h.app,
+        "POST",
+        "/functions/v1/wasm-echo",
+        &[
+            ("apikey", h.anon.as_str()),
+            ("content-type", "application/json"),
+        ],
+        Some(br#"{"name":"world"}"#.to_vec()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body_bytes.as_slice(), b"hi from wasm");
+}
+
+#[cfg(feature = "compute")]
+#[tokio::test]
+async fn invoke_missing_handler_export_is_boot_error() {
+    let h = harness().await;
+    // Valid WASM but no `handler` export → BootError with MissingExport
+    // trap surfaced.
+    let no_handler_wat = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "gdb_alloc") (param i32) (result i32) (i32.const 1024)))
+    "#;
+    let wasm = wat::parse_str(no_handler_wat).unwrap();
+    call(
+        &h.app,
+        "POST",
+        "/functions/v1/_admin/functions",
+        Some(&h.service),
+        None,
+        Some(json!({
+            "slug": "no-handler",
+            "verify_jwt": false,
+            "body": base64::engine::general_purpose::STANDARD.encode(&wasm)
+        })),
+    )
+    .await;
+
+    let (status, _, body) = call(
+        &h.app,
+        "POST",
+        "/functions/v1/no-handler",
+        Some(&h.anon),
+        None,
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_BOOT_ERROR");
+}

--- a/tests/supabase_functions.rs
+++ b/tests/supabase_functions.rs
@@ -558,7 +558,7 @@ async fn invoke_no_body_is_500_boot_error_without_compute() {
         Some(json!({
             "slug": "noop",
             "verify_jwt": false,
-            "body": base64::engine::general_purpose::STANDARD.encode(&minimal_wasm())
+            "body": base64::engine::general_purpose::STANDARD.encode(minimal_wasm())
         })),
     )
     .await;

--- a/tests/supabase_gateway.rs
+++ b/tests/supabase_gateway.rs
@@ -124,10 +124,12 @@ async fn missing_apikey_is_401_typed() {
 }
 
 #[tokio::test]
-async fn functions_service_is_501_not_404() {
+async fn functions_service_is_wired() {
     // Storage / realtime / pg-meta are implemented since stage 3 (see
-    // tests/supabase_storage_realtime.rs) and graphql since stage 4 (see
-    // tests/supabase_graphql.rs); functions keeps its precise typed 501.
+    // tests/supabase_storage_realtime.rs), graphql since stage 4 (see
+    // tests/supabase_graphql.rs), and functions since stage 5 (see
+    // tests/supabase_functions.rs). Invoking a slug that isn't deployed now
+    // returns the typed 404 shape, never a bare 404 or 501.
     let h = harness().await;
     let (status, _h, body) = call(
         &h.app,
@@ -139,9 +141,8 @@ async fn functions_service_is_501_not_404() {
         None,
     )
     .await;
-    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
-    assert_eq!(body["code"], "SUPA_COMPAT_FUNCTIONS_NOT_IMPLEMENTED");
-    assert_eq!(body["hint"], "tracked for a later slice");
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_NOT_FOUND");
 
     // A missing storage object is now a typed storage-api error, not a 501.
     let (status, _h, body) = call(

--- a/tests/supabase_storage_realtime.rs
+++ b/tests/supabase_storage_realtime.rs
@@ -1586,11 +1586,11 @@ async fn realtime_broadcast_between_subscribers() {
 }
 
 // ===========================================================================
-// Gateway: functions keeps its typed 501; graphql is live
+// Gateway: functions is live (typed 404 for undeployed slugs); graphql is live
 // ===========================================================================
 
 #[tokio::test]
-async fn functions_remains_typed_501_and_graphql_is_live() {
+async fn functions_returns_typed_not_found_and_graphql_is_live() {
     let h = harness().await;
     let (status, body) = call(
         &h.app,
@@ -1601,8 +1601,10 @@ async fn functions_remains_typed_501_and_graphql_is_live() {
         None,
     )
     .await;
-    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
-    assert_eq!(body["code"], "SUPA_COMPAT_FUNCTIONS_NOT_IMPLEMENTED");
+    // Functions layer is now wired (see tests/supabase_functions.rs). An
+    // undeployed slug renders the typed 404 shape, not the old 501 stub.
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "SUPA_COMPAT_FUNCTION_NOT_FOUND");
 
     // GraphQL is implemented (see tests/supabase_graphql.rs): a real request
     // executes and returns GraphQL-shaped JSON with HTTP 200.


### PR DESCRIPTION
## Summary

Adds a full Supabase Edge Functions-compatible surface to the supabase compat gateway, backed by the Guardian Compute WASM sandbox. Retires the previous typed-501 `/functions/v1` stub.

- **Invocation** — `POST /functions/v1/{slug}` runs deployed WebAssembly under `WasmRuntime` (fresh Store per request, hard fuel/memory/wall-clock ceiling, `gdb.log` linked). Verifies JWT when `verify_jwt=true`; forwards method/URL/headers/query/body/env/role as a CBOR-encoded `InvocationInput`; renders the guest's `InvocationOutput` (status + headers + base64 body) back as the HTTP response. `OPTIONS` is answered as a 204 CORS preflight.
- **Admin CRUD** — `/functions/v1/_admin/functions[/{slug}[/body|/secrets[/{name}]]]`: service_role-only create/list/get/patch/delete; PUT `application/wasm` bodies; per-function secrets whose values are never surfaced on read.
- **Storage** — `functions.functions`, `functions._code`, `functions.secrets` bootstrapped on first use with RLS enabled and no default policies (only `service_role` bypasses, mirroring the storage schema pattern).
- **Error taxonomy** — `{"error":"SUPA_COMPAT_FUNCTION_*", "msg":...}` covering `NotFound`, `BootError`, `RuntimeError`, `BadRequest`, `Forbidden`, `InvalidWasm`, `Internal`.

## Runtime substrate

Rather than pull in a heavy JS runtime (deno_core / rquickjs / boa), function bodies are WebAssembly modules using the existing Guardian Compute ABI (`gdb_alloc` + `handler: (ptr, len) -> i64`). This reuses the hardened wasmtime sandbox already in-tree (fuel + epoch interruption + memory limiter), stays architecturally coherent with the compute crate, and adds zero new deps. When the `compute` feature is off, admin CRUD still works and invocation returns a typed `SUPA_COMPAT_FUNCTION_BOOT_ERROR`.

## Test plan

- [x] `cargo test --features supabase --test supabase_functions` — 15/15 pass
- [x] `cargo test --features "supabase,compute" --test supabase_functions` — 17/17 pass, including two end-to-end tests that hand-craft a WASM guest (WAT + pre-baked CBOR output), deploy it via the admin API, invoke it, and verify the response body came out of the sandbox
- [x] `cargo test --features supabase --test supabase_gateway` — 24/24 pass
- [x] `cargo test --features supabase --test supabase_storage_realtime` — 18/18 pass
- [x] `cargo test --features supabase --test supabase_graphql` — passes
- [x] 49/49 supabase unit tests pass
- [x] `cargo check --features supabase` and `cargo check --features "supabase,compute"` — zero warnings

The pre-existing `sql_conformance::explain_select_for_update_takes_no_row_locks` failure on `main` is unrelated to this change (verified by stashing and re-running on the base commit).